### PR TITLE
Add CityBahn Chemnitz 

### DIFF
--- a/assets/css/line-colors.css
+++ b/assets/css/line-colors.css
@@ -209,7 +209,7 @@ Individual design on Signets is limited to color to keep a consistent look. Plea
 .CBC11city-bahn-chemnitz, .CBC13city-bahn-chemnitz, 
 .CBC14city-bahn-chemnitz, .CBC15city-bahn-chemnitz {
 	border-radius: 200px;
-	max-width: 100px;
+	/*max-width: 100px;*/
 }
 
 .CBC11city-bahn-chemnitz {
@@ -223,7 +223,7 @@ Individual design on Signets is limited to color to keep a consistent look. Plea
 }
 
 .CBC14city-bahn-chemnitz {
-	background-color: #00a1e5;
+	background-color: #5d1339;
 	color: #fff;
 }
 

--- a/assets/css/line-colors.css
+++ b/assets/css/line-colors.css
@@ -99,6 +99,7 @@ Individual design on Signets is limited to color to keep a consistent look. Plea
 }
 
 .S42s-bahn-berlin::after {
+	content: "\21BA"; /*Why does it also work without "content:"?*/
 }
 
 .S45s-bahn-berlin {

--- a/assets/css/line-colors.css
+++ b/assets/css/line-colors.css
@@ -203,6 +203,34 @@ Individual design on Signets is limited to color to keep a consistent look. Plea
 	color: #fff;
 }
 
+/* CityBahn Chemnitz (similar to S-Bahn) */
+/* Adaptation to the S-Bahn style */
+.CBC11city-bahn-chemnitz, .CBC13city-bahn-chemnitz, 
+.CBC14city-bahn-chemnitz, .CBC15city-bahn-chemnitz {
+	border-radius: 200px;
+	max-width: 100px;
+}
+
+.CBC11city-bahn-chemnitz {
+	background-color: #007946; /*VMS Green*/
+	color: #fff;
+}
+
+.CBC13city-bahn-chemnitz {
+	background-color: #CF2538; /*Chemnitz-Bahn-Logo Red*/
+	color: #fff;
+}
+
+.CBC14city-bahn-chemnitz {
+	background-color: #00a1e5;
+	color: #fff;
+}
+
+.CBC15city-bahn-chemnitz {
+	background-color: #f6df00;
+	color: #fff;
+}
+
 /* S-Bahn Rhein-Main */
 .S1db-regio-ag-s-bahn-rhein-main {
 	background-color: #0094d7;

--- a/assets/css/line-colors.css
+++ b/assets/css/line-colors.css
@@ -26,7 +26,7 @@ Please read comments carefully.
 	max-width: 100px;
 }
 
-.EN, .NJ, .EN, .ICN {
+.EN, .NJ, .ICN {
 	background-image: url('../stars.jpg');
 	background-size: 200px;
 	color: #fff ;


### PR DESCRIPTION
- add S-Bahn-Style for CityBahn Chemnitz (similar to a S-Bahn system)
- add different colors for C11, C13, C14 & C14 
- Fix double EN at NightTrain Style
- Fix missing ↺ at S42 (I have no idea why it works without)