### PR TITLE
show plattform changes & delay

### DIFF
--- a/arrival.html
+++ b/arrival.html
@@ -178,6 +178,13 @@ function updateTable(data) {
 		return entry.line.product === "suburban";
 	});
 
+	// sorts the entries by when or plannedwhen
+	data.sort(function(a, b) {
+        var timeA = a.when !== null ? a.when : a.plannedWhen;
+        var timeB = b.when !== null ? b.when : b.plannedWhen;
+        return new Date(timeA) - new Date(timeB);
+    });	
+
 	data.forEach(function(entry) {
 	// If product is bus, ferry, subway, tram or taxi
 	if (
@@ -203,7 +210,7 @@ function updateTable(data) {
 	var diffPlannedMinutes = Math.round((now - plannedDepartureTime) / (1000 * 60));
 
 	// If entry is cancelled and more than 10 mins ago skip (not neccesary to skip cancelled trips which should have been departed already. may increase or decrease the time 
-	if (isCancelled && diffPlannedMinutes < 0) {
+	if (isCancelled && diffPlannedMinutes > 0) {
 		return;
 	}
 
@@ -216,9 +223,11 @@ function updateTable(data) {
 	}
     
 	// Format time stemps to actual readable format and add a cloosing door icon i needed
-	var formattedWhen = formatTime(entry.when);
-	var formattedPlannedWhen = formatTime(entry.plannedWhen);
-	var abMessage = getAbMessage(entry.when);
+	//var formattedWhen = formatTime(entry.when);
+	//var formattedPlannedWhen = formatTime(entry.plannedWhen);
+	
+	// add clossing door gif (only when not cancelled)
+	var abMessage = (isCancelled) ? "" : getAbMessage(entry.when);
 
 	row.insertCell(0).innerHTML = '<div class="linebadge '+ entry.line.product + ' ' + entry.line.name.replace(/\s/g, '') + entry.line.operator.id + ' ' + entry.line.productName +'">'+ entry.line.name +'</div>';
 	
@@ -229,7 +238,26 @@ function updateTable(data) {
 
 	var countdownCell = row.insertCell(1);
 
-	countdownCell.textContent = formatTime(entry.when);
+	// Calculate delay in minutes
+    var timeDifference = Math.abs(departureTime - plannedDepartureTime) / (1000 * 60);
+		
+	if (entry.when === null) {
+		countdownCell.textContent = formatTime(entry.plannedWhen);
+	} else {
+		if (timeDifference > 5) { //delay more then 5 minutes -> time in red & delay in minutes (planned time in Hovertext)
+			countdownCell.innerHTML = "<span class=tooltip style='color: #ec0016;'>" + formatTime(entry.when) + " <i>(+" + timeDifference + ")</i><span class=tooltiptext>" + formatTime(entry.plannedWhen) + "</span></span>";
+			
+			//countdownCell.innerHTML = "<s><i>" + formatTime(entry.plannedWhen) + "</s></i> <span style='color: #ec0016;'>" + formatTime(entry.when) + "</span>";
+		} else { 
+			if (timeDifference > 0) { //short delay -> time in orange (planned time and delay in minutes in Hovertext)
+				countdownCell.innerHTML = "<span class=tooltip style='color: #ff6600;'> " + formatTime(entry.when) + "<span class=tooltiptext>" + formatTime(entry.plannedWhen) + " (+" + timeDifference + ")</span></span>";
+
+				//countdownCell.innerHTML = "<span style='color: #ff6600;'> " + formatTime(entry.when) + "</span>";
+			} else {
+				countdownCell.textContent = formatTime(entry.when);
+			}
+		}
+	}
 
 	var wideCell2 = row.insertCell(2);
 	// Create link to the trip information tab
@@ -237,7 +265,17 @@ function updateTable(data) {
 	wideCell2.className = 'wide';
 	wideCell2.classList.add('boardcell');
 	
-	row.insertCell(3).textContent = entry.platform;
+	// Check for Platform changes
+	if (entry.platform == entry.plannedPlatform){
+		row.insertCell(3).textContent = entry.plannedPlatform;
+	} else { 
+		if (entry.plannedPlatform === null) { //some Trains have no planned platform
+			row.insertCell(3).innerHTML = "<span style='color: #ec0016;'> " + entry.platform + "</span>";
+		} else {
+			row.insertCell(3).innerHTML = "<s>" + entry.plannedPlatform + "</s><span style='color: #ec0016;'> " + entry.platform + "</span>";
+		}
+	}
+
 	var cell = row.insertCell(4);
 	cell.innerHTML = abMessage;
 	cell.classList.add("zerotable");

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -376,7 +376,7 @@ td {
 	color: #fff;
 	text-align: center;
 	font-weight: bold;
-	padding 5px;
+	padding: 5px;
 
 }
 
@@ -386,7 +386,7 @@ td {
 	color: #fff;
 	text-align: center;
 	font-weight: bold;
-	padding 30px;
+	padding: 30px;
 	font-size: 22px;
 
 }
@@ -483,10 +483,6 @@ td {
 	.departtime {
 		font-size: 46px;
 	}
-	
-
-	
-	
 }
 
 @media (min-width: 1300px) {
@@ -517,9 +513,35 @@ td {
 	}
 	
 	.mini {
-	height: 45px;
-	
+		height: 45px;	
+	}
 }
 
-
+.tooltip {
+	position: relative;
+	display: inline-block;
+	/*border-bottom: 1px dotted black;*/ /* If you want dots under the hoverable text */
+}
+  
+.tooltip .tooltiptext {
+	visibility: hidden;
+	width: 150px;
+	background-color: black;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 0;
+	font-size: 18px;
+	
+	/* Position the tooltip */
+	position: absolute;
+	z-index: 1;
+	top: 100%;
+	left: 50%;
+	margin-left: -60px;
+	
+}
+  
+.tooltip:hover .tooltiptext {
+	visibility: visible;
 }

--- a/departure.html
+++ b/departure.html
@@ -175,6 +175,13 @@ function updateTable(data) {
 		return entry.line.product === "suburban";
 	});
 
+	// sorts the entries by when or plannedwhen
+	data.sort(function(a, b) {
+        var timeA = a.when !== null ? a.when : a.plannedWhen;
+        var timeB = b.when !== null ? b.when : b.plannedWhen;
+        return new Date(timeA) - new Date(timeB);
+    });
+
 	data.forEach(function(entry) {
 		// If product is bus, ferry, subway, tram or taxi
 		if (
@@ -188,6 +195,7 @@ function updateTable(data) {
 			// skip this entry (not needed for a TRAIN ONLY board)
 			return;
 		}
+
 	// if trip is cancelled
 	var isCancelled = entry.remarks.some(function(remark) {
 		return remark.type === "status" && remark.code === "cancelled";
@@ -199,7 +207,7 @@ function updateTable(data) {
 	var diffPlannedMinutes = Math.round((now - plannedDepartureTime) / (1000 * 60));
 
 	// If entry is cancelled and more than 10 mins ago skip (not neccesary to skip cancelled trips which should have been departed already. may increase or decrease the time 
-	if (isCancelled && diffPlannedMinutes < 0) {
+	if (isCancelled && diffPlannedMinutes > 0) {
 		return;
 	}
 
@@ -211,21 +219,42 @@ function updateTable(data) {
 		row.style.textDecoration = "line-through";
 	}
     
-	// Format time stemps to actual readable format and add a cloosing door icon i needed
-	var formattedWhen = formatTime(entry.when);
-	var formattedPlannedWhen = formatTime(entry.plannedWhen);
-	var abMessage = getAbMessage(entry.when);
+	// Format time stemps to actual readable format
+	//var formattedWhen = formatTime(entry.when);
+	//var formattedPlannedWhen = formatTime(entry.plannedWhen);
+	
+	// add clossing door gif (only when not cancelled)
+	var abMessage = (isCancelled) ? "" : getAbMessage(entry.when);
 
-	row.insertCell(0).innerHTML = '<div class="linebadge '+ entry.line.product + ' ' + entry.line.name.replace(/\s/g, '') + entry.line.operator.id + ' ' + entry.line.productName +'">'+ entry.line.name +'</div>';
+	row.insertCell(0).innerHTML = '<div class="linebadge '+ entry.line.product + ' ' + entry.line.name.replace(/\s/g, '') + entry.line.operator.id + ' ' + entry.line.operator.id + ' ' + entry.line.productName +'">'+ entry.line.name +'</div>';
 	
 	// Calculate minutes from time now - departing time (needed for the countdown in sbahn tab)
 	var now = new Date();
 	var departureTime = new Date(entry.when);
 	var diffMinutes = Math.round((departureTime - now) / (1000 * 60));
-    
+    	
 	var countdownCell = row.insertCell(1);
-    
-	countdownCell.textContent = formatTime(entry.when);
+
+	// Calculate delay in minutes
+    var timeDifference = Math.abs(departureTime - plannedDepartureTime) / (1000 * 60);
+	
+	if (entry.when === null) {
+		countdownCell.textContent = formatTime(entry.plannedWhen);
+	} else {
+		if (timeDifference > 5) { //delay more then 5 minutes -> time in red & delay in minutes (planned time in Hovertext)
+			countdownCell.innerHTML = "<span class=tooltip style='color: #ec0016;'>" + formatTime(entry.when) + " <i>(+" + timeDifference + ")</i><span class=tooltiptext>" + formatTime(entry.plannedWhen) + "</span></span>";
+			
+			//countdownCell.innerHTML = "<s><i>" + formatTime(entry.plannedWhen) + "</s></i> <span style='color: #ec0016;'>" + formatTime(entry.when) + "</span>";
+		} else { 
+			if (timeDifference > 0) { //short delay -> time in orange (planned time and delay in minutes in Hovertext)
+				countdownCell.innerHTML = "<span class=tooltip style='color: #ff6600;'> " + formatTime(entry.when) + "<span class=tooltiptext>" + formatTime(entry.plannedWhen) + " (+" + timeDifference + ")</span></span>";
+
+				//countdownCell.innerHTML = "<span style='color: #ff6600;'> " + formatTime(entry.when) + "</span>";
+			} else {
+				countdownCell.textContent = formatTime(entry.when);
+			}
+		}
+	}
 
 	var wideCell2 = row.insertCell(2);
 	
@@ -234,8 +263,32 @@ function updateTable(data) {
 	wideCell2.className = 'wide';
 	wideCell2.classList.add('boardcell');
 	
-	row.insertCell(3).textContent = entry.platform;
+	// Check for Platform changes
+	if (entry.platform == entry.plannedPlatform){
+		row.insertCell(3).textContent = entry.plannedPlatform;
+	} else { 
+		if (entry.plannedPlatform === null) { //some Trains have no planned platform
+			row.insertCell(3).innerHTML = "<span style='color: #ec0016;'> " + entry.platform + "</span>";
+		} else {
+			row.insertCell(3).innerHTML = "<s>" + entry.plannedPlatform + "</s><span style='color: #ec0016;'> " + entry.platform + "</span>";
+		}
+	}
+
 	var cell = row.insertCell(4);
+
+	/*
+	// Show info-messages (the look needs to be improved)
+	if (entry.remarks.length > 0) {
+		var InfoMessage = ''; // = row.insertCell(5);
+		for (var i = 0; i < entry.remarks.length; i++) {
+			if (i > 0) { InfoMessage += " +++ ";}
+			InfoMessage += entry.remarks[i].text;
+		}
+		//console.log(entry.line.name + ": " + InfoMessage);
+		row.insertCell(5).textContent = InfoMessage;
+	}
+	*/
+
 	cell.innerHTML = abMessage;
 	cell.classList.add("zerotable");
 });
@@ -260,7 +313,6 @@ function getAbMessage(dateTimeString) {
 	var now = new Date();
 
 	var diffMinutes = Math.round((dateTime - now) / (1000 * 60));
-
 	return diffMinutes <= 0 ? '<img src="./assets/depart.gif" class="mini">' : '';
 }
 

--- a/suburban.html
+++ b/suburban.html
@@ -176,6 +176,13 @@ function updateTable(data) {
 		return entry.line.product === "suburban";
 	});
 
+	// sorts the entries by when or plannedwhen
+	data.sort(function(a, b) {
+        var timeA = a.when !== null ? a.when : a.plannedWhen;
+        var timeB = b.when !== null ? b.when : b.plannedWhen;
+        return new Date(timeA) - new Date(timeB);
+    });
+
 	data.forEach(function(entry) {
 		// If product is bus, ferry, subway, tram or taxi
 		if (
@@ -195,7 +202,7 @@ function updateTable(data) {
 	var diffPlannedMinutes = Math.round((now - plannedDepartureTime) / (1000 * 60));
 
 	// If entry is cancelled and more than 10 mins ago skip (not neccesary to skip cancelled trips which should have been departed already. may increase or decrease the tim
-	if (isCancelled && diffPlannedMinutes < 0) {
+	if (isCancelled && diffPlannedMinutes > 0) {
 		return;
 	}
 
@@ -210,7 +217,9 @@ function updateTable(data) {
 	// Format time stemps to actual readable format and add a cloosing door icon i needed
 	var formattedWhen = formatTime(entry.when);
 	var formattedPlannedWhen = formatTime(entry.plannedWhen);
-	var abMessage = getAbMessage(entry.when);
+
+	// add clossing door gif (only when not cancelled)
+	var abMessage = (isCancelled) ? "" : getAbMessage(entry.when);
 
 	row.insertCell(0).innerHTML = '<div class="linebadge '+ entry.line.product + ' ' + entry.line.name.replace(/\s/g, '') + entry.line.operator.id +'">'+ entry.line.name.replace(/\s/g, '') +'</div>';
     
@@ -220,11 +229,15 @@ function updateTable(data) {
 	var diffMinutes = Math.round((departureTime - now) / (1000 * 60));
     
 	var countdownCell = row.insertCell(1);
-    
-	if (diffMinutes <= 0) {
-		
-		countdownCell.innerHTML = 'jetzt';
-      
+
+	// Calculate delay in minutes
+	var timeDifference = Math.abs(departureTime - plannedDepartureTime) / (1000 * 60);
+	
+	if (entry.when === null) {
+		countdownCell.textContent = formatTime(entry.plannedWhen);
+	} else if (diffMinutes <= 0) {
+		countdownCell.textContent = 'jetzt';
+
 		setInterval(function() {
 			diffMinutes = Math.round((departureTime - new Date()) / (1000 * 60));
 			if (diffMinutes <= 60) {
@@ -233,12 +246,15 @@ function updateTable(data) {
 				countdownCell.textContent = formatTime(entry.when);
 			}
 		}, 60000);
-      
 	} else if (diffMinutes <= 60) {
 		// Show countdown instead of departing times when departing time is <= 60 min away from now
-		countdownCell.innerHTML = diffMinutes + '<span class="additional">&nbsp;min.</span>';
-      
-		// Reload eery 60 secs
+		if (timeDifference > 5) { //delay more then 5 minutes -> time in red
+			countdownCell.innerHTML = "<span style='color: #ec0016;'>" + diffMinutes + '<span class="additional">&nbsp;min.</span></span>'; 
+		} else {
+			countdownCell.innerHTML = diffMinutes + '<span class="additional">&nbsp;min.</span>';
+		}
+		
+		// Reload every 60 secs
 		setInterval(function() {
 			diffMinutes = Math.round((departureTime - new Date()) / (1000 * 60));
 			if (diffMinutes <= 60) {
@@ -247,10 +263,16 @@ function updateTable(data) {
 				countdownCell.textContent = formatTime(entry.when);
 			}
 		}, 60000);
-      
-	} else {
-		// Show departing time if it is >60min away
-		countdownCell.textContent = formattedWhen;
+	} else { // Show departing time if it is >60min away
+		if (timeDifference > 5) { //delay more then 5 minutes -> time in red & delay in minutes (planned time in Hovertext)
+			countdownCell.innerHTML = "<span class=tooltip style='color: #ec0016;'>" + formatTime(entry.when) + " <i>(+" + timeDifference + ")</i><span class=tooltiptext>" + formatTime(entry.plannedWhen) + "</span></span>";
+			//countdownCell.innerHTML = "<s><i>" + formatTime(entry.plannedWhen) + "</s></i> <span style='color: #ec0016;'>" + formatTime(entry.when) + "</span>";
+		} else if (timeDifference > 0) { //short delay -> time in orange (planned time and delay in minutes in Hovertext)
+			countdownCell.innerHTML = "<span class=tooltip style='color: #ff6600;'> " + formatTime(entry.when) + "<span class=tooltiptext>" + formatTime(entry.plannedWhen) + " (+" + timeDifference + ")</span></span>";
+			//countdownCell.innerHTML = "<span style='color: #ff6600;'> " + formatTime(entry.when) + "</span>";
+		} else {
+			countdownCell.textContent = formatTime(entry.when);
+		}
 	}
 
 	var wideCell2 = row.insertCell(2);
@@ -259,7 +281,17 @@ function updateTable(data) {
 	wideCell2.className = 'wide';
 	wideCell2.classList.add('boardcell');
 	
-	row.insertCell(3).textContent = entry.platform;
+	// Check for Platform changes
+	if (entry.platform == entry.plannedPlatform){
+		row.insertCell(3).textContent = entry.plannedPlatform;
+	} else { 
+		if (entry.plannedPlatform === null) { //some Trains have no planned platform
+			row.insertCell(3).innerHTML = "<span style='color: #ec0016;'> " + entry.platform + "</span>";
+		} else {
+			row.insertCell(3).innerHTML = "<s>" + entry.plannedPlatform + "</s><span style='color: #ec0016;'> " + entry.platform + "</span>";
+		}
+	}
+	
 	var cell = row.insertCell(4);
 	cell.innerHTML = abMessage;
 	cell.classList.add("zerotable");


### PR DESCRIPTION
### Changes:
- Platform changes are displayed in red, with the old platform crossed out.
- Delay is displayed:
  - Delay over 5min: Time is shown in red with the delay in minutes "(+x)" following it. A hover text shows the original time.
  - minor delays: Time is shown in orange. A hover text displays the original time and the delay in minutes "(+x)".
  - S-Bahn: Display time in red if delayed by more than 5 minutes.

- Trains are sorted by departure/arrival time (if When=null, then by plannedWhen).
- Cancelled trains are displayed correctly.
- S-Bahn: Cancelled trains are displayed with the planned departure time.
- Fix: Closing Door Gif is not displayed when the train is cancelled.
- Fix in styles.css with missing ":".

- Preparing to Display Train Remarks. (The appearance needs to be improved, therefore the code is only a 

### Ideas for Color Fix line:
- [ ] RE should get its own color or that of IRE.
- [ ] REs from DB Fern (ICE/IC mit Nahverkehrsfreigabe) need maybe a own color. 
- [ ] The Color from the S9 Rhein-Main is to similar to the rail replacement bus
