### PR TITLE
Fix - Text wasn't aligned with the image of the contributor

### DIFF
--- a/about.html
+++ b/about.html
@@ -59,7 +59,7 @@ fetch('https://api.github.com/repos/hoolycrash/trainboard/contributors')
     data.forEach(contributor => {
       const div = document.createElement('div');
       div.innerHTML = `
-        <a href="${contributor.html_url}" class="black">
+        <a class="contributor" href="${contributor.html_url}" class="black">
           <img src="${contributor.avatar_url}" alt="${contributor.login}" class="avatar">
           <strong>${contributor.login}</strong>
           <span class="green"> +${contributor.contributions}</span>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -780,6 +780,11 @@ td {
 	visibility: visible;
 }
 
+.contributor {
+	display: flex;
+	gap: 0.5rem;
+}
+
 
 @media (min-width: 300px) {
 


### PR DESCRIPTION
Fixed that the contributor name and the image wheren't at the same horizontal line.

Before
![image](https://github.com/user-attachments/assets/39339a62-c62b-4fb8-b56e-cacb95ccbf11)

After
![image](https://github.com/user-attachments/assets/e47a9239-47c2-4d51-bc86-329dde6fef6a)
